### PR TITLE
bump version

### DIFF
--- a/lib/fog/powerdns/version.rb
+++ b/lib/fog/powerdns/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module PowerDNS
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
`0.1.1` is out on [rubygems](https://rubygems.org/gems/fog-powerdns) so this PR bumps it to `0.1.2` so I can specify this repo and version in my `Gemfile` until a new version is uploaded to rubygems.