### PR TITLE
Fix Fog::DNS::PowerDNS::Zones.all() and .get()

### DIFF
--- a/lib/fog/dns/powerdns/models/zones.rb
+++ b/lib/fog/dns/powerdns/models/zones.rb
@@ -20,7 +20,7 @@ module Fog
         end
 
         def get(zone)
-          data = service.get_zone(DEFAULT_SERVER, zone).body['zone']
+          data = service.get_zone(DEFAULT_SERVER, zone)
           zone = new(data)
           zone
         rescue Fog::Service::NotFound

--- a/lib/fog/dns/powerdns/models/zones.rb
+++ b/lib/fog/dns/powerdns/models/zones.rb
@@ -9,16 +9,18 @@ module Fog
       class Zones < Fog::Collection
         model Fog::DNS::PowerDNS::Zone
 
+        DEFAULT_SERVER = 'localhost'
+        
         # attribute :zone,    :aliases => 'name'
 
         def all
           clear
-          data = service.list_zones.body
+          data = service.list_zones(DEFAULT_SERVER)
           load(data)
         end
 
         def get(zone)
-          data = service.get_zone(zone).body['zone']
+          data = service.get_zone(DEFAULT_SERVER, zone).body['zone']
           zone = new(data)
           zone
         rescue Fog::Service::NotFound


### PR DESCRIPTION
I was trying

```ruby
dns = Fog::DNS::PowerDNS.new({
  :host => host,
  :pdns_api_key => key
})

zones = dns.zones.all
zone = dns.zones.get('example.org')
```

And it was failing with
```
fog-powerdns-0.2.1/lib/fog/dns/powerdns/requests/get_zone.rb:37:in `get_zone': wrong number of arguments (given 1, expected 2) (ArgumentError)
fog-powerdns-0.2.1/lib/fog/dns/powerdns/models/zones.rb:21:in `get'
```

This is because `list_zones` and `get_zone` require a server parameter. See [get_zone.rb](/fog/fog-powerdns/blob/master/lib/fog/dns/powerdns/requests/get_zone.rb#L37)
