### PR TITLE
Fix zones.create()

### DIFF
--- a/lib/fog/dns/powerdns/models/zone.rb
+++ b/lib/fog/dns/powerdns/models/zone.rb
@@ -9,7 +9,10 @@ module Fog
         identity :zone_id
 
         attribute :zone, aliases: 'name'
+        attribute :kind
         attribute :server_id
+
+        DEFAULT_SERVER = 'localhost'
 
         def destroy
           service.delete_zone(identity)
@@ -27,8 +30,8 @@ module Fog
         end
 
         def save
-          requires :zone
-          data = service.create_zone(zone).body['zone']
+          requires :zone, :kind
+          data = service.create_zone(DEFAULT_SERVER, zone, kind)
           merge_attributes(data)
           true
         end

--- a/lib/fog/dns/powerdns/requests/create_zone.rb
+++ b/lib/fog/dns/powerdns/requests/create_zone.rb
@@ -5,12 +5,12 @@ module Fog
     class PowerDNS
       class Real
         # Create a single zone in PowerDNS
-        # Server, name and nameservers LIST are required
+        # Server, name and kind are required
         #
         # ==== Parameters
         # * server<~String> - Server ID
         # * name<~String> - Name of domain
-        # * nameservers<~Array> - List of nameservers
+        # * kind<~String> - Zone kind, one of 'Native', 'Master', 'Slave', 'Producer', 'Consumer'
         # * options<~Hash> - Other options
         #
         # ==== Returns
@@ -38,10 +38,11 @@ module Fog
         #     * 'comments': <~Array>,
         #   * status<~Integer>  201 when successful
 
-        def create_zone(server, name, nameservers, options = {})
+        def create_zone(server, name, kind, options = {})
           body = {
             'name' => name,
-            'nameservers' => nameservers
+            'kind' => kind,
+            'nameservers' => []
           }
 
           options.each do |option, value|


### PR DESCRIPTION
Fix `zones.create()`

server and `kind` is required

```ruby
zone = dns.zones.create(zone: 'example.org', kind: 'Native')
```
