### PR TITLE
Fix update_zone status code

### DIFF
--- a/lib/fog/dns/powerdns/requests/update_zone.rb
+++ b/lib/fog/dns/powerdns/requests/update_zone.rb
@@ -46,7 +46,7 @@ module Fog
 
           request(
             body: Fog::JSON.encode(body),
-            expects: 200,
+            expects: 204,
             method: 'PUT',
             path: "/api/#{@api_version}/servers/#{server}/zones/#{zone}"
           ).body


### PR DESCRIPTION
Zones update returns 204 No Content on success not 200.

See https://doc.powerdns.com/authoritative/http-api/zone.html#put--servers-server_id-zones-zone_id
